### PR TITLE
Fix updcookie

### DIFF
--- a/core/util/utilities/updcookie.py
+++ b/core/util/utilities/updcookie.py
@@ -28,7 +28,7 @@ class Updcookie(BaseUtil):
 		)
 
 
-	def main(self, argv, opts, db_file=None):
+	def main(self, args, opts, db_file=None):
 		qry = """
 			SELECT id, cookies
 			FROM request 


### PR DESCRIPTION
Trivial fix to resolve the following bug when running updcookie:
```
  File "/usr/local/share/htcap/core/util/utilities/updcookie.py", line
  38, in main
      dbfile = args[0]
      NameError: global name 'args' is not defined
```