### PR TITLE
Fix AttributeError in Wapiti Scanner

### DIFF
--- a/core/scan/scanners/wapiti.py
+++ b/core/scan/scanners/wapiti.py
@@ -115,7 +115,7 @@ class Wapiti(BaseScanner):
 				domain = cookie.domain
 				if domain:
 					if not domain.startswith("."): domain = ".%s" % domain
-				else:
+				elif cookie.setter:
 					domain = cookie.setter.hostname
 
 				if not domain in wcookies.keys():


### PR DESCRIPTION
Fixes the following bug:
```
  File "/usr/local/share/htcap/core/scan/scanners/wapiti.py", line 119, in
  convert_cookies
      domain = cookie.setter.hostname
      AttributeError: 'NoneType' object has no attribute 'hostname'
```