### PR TITLE
Add Sqlmap Extra Header Support

### DIFF
--- a/core/scan/scanners/sqlmap.py
+++ b/core/scan/scanners/sqlmap.py
@@ -121,6 +121,17 @@ class Sqlmap(BaseScanner):
 			if self.scanner.proxy:
 				cmd.extend(("--proxy", "%s://%s:%s" % (self.scanner.proxy['proto'], self.scanner.proxy['host'], self.scanner.proxy['port'])))
 
+			extra_headers = []
+			for hn in self.request.extra_headers:
+				if hn not in self.scanner.extra_headers:
+					extra_headers.append(hn + ":" + self.request.extra_headers[hn])
+
+			for hn in self.scanner.extra_headers:
+				extra_headers.append(hn + ":" + self.scanner.extra_headers[hn])
+
+			if len(extra_headers) > 0:
+				cmd.extend(("--headers", "\n".join(extra_headers)))
+
 			out = None
 			#self.sprint(cmd_to_str(cmd))
 			try:


### PR DESCRIPTION
Augment sqlmap scanner requests with the headers from the original request.
Also, add extra headers specified on the command-line, overriding headers from the original request with the same name.