### PR TITLE
Add Arachni Extra Header Support

### DIFF
--- a/core/scan/scanners/arachni.py
+++ b/core/scan/scanners/arachni.py
@@ -134,6 +134,17 @@ class Arachni(BaseScanner):
 				cmd.extend(['--http-proxy-type', self.scanner.proxy['proto']])
 				cmd.extend(['--http-proxy', '%s:%s' % (self.scanner.proxy['host'], self.scanner.proxy['port'])])
 
+			extra_headers = []
+			for hn in self.request.extra_headers:
+				if hn not in self.scanner.extra_headers:
+					extra_headers.append(hn + "=" + self.request.extra_headers[hn])
+
+			for hn in self.scanner.extra_headers:
+				extra_headers.append(hn + "=" + self.scanner.extra_headers[hn])
+
+			for header in extra_headers:
+				cmd.extend(("--http-request-header", header))
+
 			cmd.append(self.request.url)
 
 			if not self.scanner.execute_command:


### PR DESCRIPTION
Augment arachni scanner requests with the headers from the original
request.
Also, add extra headers specified on the command-line, overriding
headers from the original request with the same name.