### PR TITLE
Update shebang for scripts to use Python 3

### DIFF
--- a/core/lib/thirdparty/pysocks/sockshandler.py
+++ b/core/lib/thirdparty/pysocks/sockshandler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 SocksiPy + urllib2 handler
 

--- a/scripts/htmlreport.py
+++ b/scripts/htmlreport.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*- 
 
 


### PR DESCRIPTION
Use Python 3 with the following scripts:
- core/lib/thirdparty/pysocks/sockshandler.py
- scripts/htmlreport.py